### PR TITLE
_gnome-4.0.scss: fixup Fractal account switcher text color

### DIFF
--- a/themes/src/sass/gtk/apps/_gnome-4.0.scss
+++ b/themes/src/sass/gtk/apps/_gnome-4.0.scss
@@ -2014,3 +2014,13 @@ list.music-list {
 notebook scrolledwindow treeview.treeview-spacing {
 	background-color: $background;
 }
+
+//
+// Fractal
+//
+.account-switcher-row label {
+	color: $text;
+}
+.account-switcher-row label.dim-label {
+	color: $text-secondary;
+}


### PR DESCRIPTION
This makes account switcher text actually readable in Fractal.