### PR TITLE
Fix name argument.

### DIFF
--- a/themes/install.sh
+++ b/themes/install.sh
@@ -619,8 +619,8 @@ install_theme() {
 	for theme in "${themes[@]}"; do
 		for color in "${colors[@]}"; do
 			for size in "${sizes[@]}"; do
-				install "${dest:-$DEST_DIR}" "${_name:-$THEME_NAME}" "$theme" "$color" "$size" "$ctype" "$window"
-				make_gtkrc "${dest:-$DEST_DIR}" "${_name:-$THEME_NAME}" "$theme" "$color" "$size" "$ctype" "$window"
+				install "${dest:-$DEST_DIR}" "${name:-$THEME_NAME}" "$theme" "$color" "$size" "$ctype" "$window"
+				make_gtkrc "${dest:-$DEST_DIR}" "${name:-$THEME_NAME}" "$theme" "$color" "$size" "$ctype" "$window"
 			done
 		done
 	done


### PR DESCRIPTION
Name argument wasn't used for installation, but was used for symlinking in `.config/gtk-4.0`.