### PR TITLE
(fix) dashtodock dash-background and outline

### DIFF
--- a/themes/src/sass/gnome-shell/extensions-40-0/_dash-to-dock.scss
+++ b/themes/src/sass/gnome-shell/extensions-40-0/_dash-to-dock.scss
@@ -99,10 +99,10 @@
 			$variant == 'light',
 			rgba($white, 0.45),
 			rgba($black, 0.85)
-		);
+		) !important;
 
 		@if $float == 'true' {
-			border: 2px solid $primary;
+			border: 2px solid $primary !important;
 		}
 	}
 


### PR DESCRIPTION
this fixes the dash pannel not beeing colored correctly if dashtodock is installed